### PR TITLE
support string interpolation in config.

### DIFF
--- a/angel.cabal
+++ b/angel.cabal
@@ -92,6 +92,6 @@ Executable angel
   -- Extra tools (e.g. alex, hsc2hs, ...) needed to build the source.
   -- Build-tools:         
 
-  Extensions: OverloadedStrings,ScopedTypeVariables,BangPatterns
+  Extensions: OverloadedStrings,ScopedTypeVariables,BangPatterns,ViewPatterns
   
   Ghc-Options: -threaded 


### PR DESCRIPTION
For example, this patch allow angel configured like this, taking advantage of interpolation feature of configurator package :

```
services = "/path/to/services"
test {
        root = "$(services)/myprogram"
        exec = "$(test.root)/myprogram"
        stdout = "$(test.root)/myprogram.stdout"
        stderr = "$(test.root)/myprogram.stderr"
        delay = 2
}
```
