### PR TITLE
Expand ~ character in paths

### DIFF
--- a/test/Angel/UtilSpec.hs
+++ b/test/Angel/UtilSpec.hs
@@ -1,0 +1,27 @@
+module Angel.UtilSpec (spec) where
+
+import Angel.Util
+
+import System.Posix.User (getEffectiveUserID,
+                          getUserEntryForID,
+                          UserEntry(..))
+
+import Test.Hspec
+import qualified Test.Hspec as H (Spec)
+
+spec :: H.Spec
+spec = do
+  describe "expandPath" $ do
+    it "generates the correct path for just a tilde" $ do
+      UserEntry { homeDirectory = home } <- getUserEntry
+      path <- expandPath "~/foo"
+      path `shouldBe` home ++ "/foo"
+    it "generates the correct path for tilde with a specific user" $ do
+      UserEntry { homeDirectory = home,
+                  userName      = user } <- getUserEntry
+      path <- expandPath $ "~" ++ user ++ "/foo"
+      path `shouldBe` home ++ "/foo"
+    it "leaves paths without tildes alone" $ do
+      path <- expandPath "/foo"
+      path `shouldBe` "/foo"
+  where getUserEntry = getUserEntryForID =<< getEffectiveUserID


### PR DESCRIPTION
This should resolve #9. This does not rely on the shell to expand paths,
only on POSIX commands.
