### PR TITLE
add note about pidfile not being created without option being set

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ Then, a series of corresponding configuration commands follow:
    created. If you don't specify an absolute path, it will use the running
    directory of angel. When combined with the `count` option, specifying a
    pidfile of `worker.pid`, it will generate `worker-1.pid`, `worker-2.pid`,
-   etc.
+   etc. If you don't specify a `pidfile` directive, then `angel` will *not*
+   create a pidfile
  * `env` is a nested config of string key/value pairs. Non-string values are
    invalid.
  * `termgrace` is an optional number of seconds to wait between


### PR DESCRIPTION
Without this, it's possible to read the docs two ways:
1. angel doesn't create a pidfile at all without `pidfile` being specified (correct)
2. angel creates a `pidfile` with the job name (incorrect)
