### PR TITLE
This dependency is unused within the Angel code

### DIFF
--- a/angel.cabal
+++ b/angel.cabal
@@ -79,7 +79,6 @@ Executable angel
   Build-depends: time
   Build-depends: old-locale
   Build-depends: text>=0.11
-  Build-depends: unix-process-conduit >= 0.2.0
 
 
   -- Modules not exported by this package.


### PR DESCRIPTION
I noticed that you have already removed this dependency in your 29-logger-zombies branch, but I cannot do a fresh build without removing it.  If others are having the same problem, then they would also benefit from this change.