### PR TITLE
Allow specification of the user a program runs as ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Each program that should be supervised starts a `program-id` block:
 Then, a series of corresponding configuration commands follow:
 
  * `exec` is the exact command line to run (required)
+ * `user` is the user the program will run as (optional, defaults to the
+   user angel is launched as)
  * `stdout` is a path to a file where the program's standard output 
     should be appended (optional, defaults to /dev/null)
  * `stderr` is a path to a file where the program's standard error

--- a/src/Angel/Config.hs
+++ b/src/Angel/Config.hs
@@ -31,7 +31,8 @@ import Data.Maybe ( isNothing
 import Data.Monoid ( (<>) )
 import qualified Data.Text as T
 import Angel.Job ( syncSupervisors )
-import Angel.Data ( Program( exec
+import Angel.Data ( Program( user
+                           , exec
                            , delay
                            , stdout
                            , stderr
@@ -91,6 +92,9 @@ checkConfigValues progs = mapM_ checkProgram (M.elems progs) >> return progs
 modifyProg :: Program -> String -> Value -> Program
 modifyProg prog "exec" (String s) = prog {exec = Just (T.unpack s)}
 modifyProg _ "exec" _ = error "wrong type for field 'exec'; string required"
+
+modifyProg prog "user" (String s) = prog{user = Just (T.unpack s)}
+modifyProg _ "user" _ = error "wrong type for field 'user'; string required"
 
 modifyProg prog "delay" (Number n) | n < 0     = error "delay value must be >= 0"
                                    | otherwise = prog{delay = Just $ round n}

--- a/src/Angel/Data.hs
+++ b/src/Angel/Data.hs
@@ -44,6 +44,7 @@ type FileRequest = (String, TChan (Maybe Handle))
 data Program = Program {
   name       :: String,
   exec       :: Maybe String,
+  user       :: Maybe String,
   delay      :: Maybe Int,
   stdout     :: Maybe String,
   stderr     :: Maybe String,
@@ -68,7 +69,7 @@ type Spec = [Program]
 -- |a template for an empty program; the variable set to ""
 -- |are required, and must be overridden in the config file
 defaultProgram :: Program
-defaultProgram = Program "" Nothing Nothing Nothing Nothing Nothing Nothing Nothing [] Nothing
+defaultProgram = Program "" Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing [] Nothing
 
 defaultDelay :: Int
 defaultDelay = 5

--- a/src/Angel/Main.hs
+++ b/src/Angel/Main.hs
@@ -34,7 +34,6 @@ import Angel.Data (GroupConfig(GroupConfig),
                    spec)
 import Angel.Job (pollStale,
                   syncSupervisors)
-import Angel.Files (startFileManager)
 
 -- |Signal handler: when a HUP is trapped, write to the wakeSig Tvar
 -- |to make the configuration monitor loop cycle/reload
@@ -82,7 +81,6 @@ runWithConfigPath configPath = do
 
     -- Fork off an ongoing state monitor to watch for inconsistent state
     forkIO $ pollStale sharedGroupConfig
-    forkIO $ startFileManager fileReqChan
 
     -- Finally, run the config load/monitor thread
     forkIO $ forever $ monitorConfig configPath sharedGroupConfig wakeSig


### PR DESCRIPTION
...via the configration command `user`.

This is the pull request that relates to the rework proposed in pull request #36

I have removed the strange getFIle implementation in favour of just the plain openFile call.  It is now in a new forked process so there should not be any threading issues with it any more.

The main bulk of the work was in Angel.Job superviseSpawner (called from supervise) which forks the angel process and makes a call to switchUser if the `user` configuration has been specified.  This process does not quit until the program being supervised quits. 

If a logger process is specified, it is also launched with the same user .