### PR TITLE
Needs GHC >= 7.4 due to Data.Monoid.<>

### DIFF
--- a/angel.cabal
+++ b/angel.cabal
@@ -36,7 +36,7 @@ Executable angel
   Hs-Source-Dirs: src
   Main-is: Angel/Main.hs
 
-  Build-depends: base >= 4.0 && < 5
+  Build-depends: base >= 4.5 && < 5
   Build-depends: process >= 1.2.0.0 && < 2.0
   Build-depends: mtl
   Build-depends: configurator >= 0.1


### PR DESCRIPTION
I revised existing versions (http://hackage.haskell.org/package/angel/revisions/) so a new release is only necessary if you want to add backwards compatibility. The build error can be fixed by using `mappend` instead of `<>`, but there may also be other errors I didn't see because of this.

Build matrix (may have been updated to include my revisions depending on when you look): http://matrix.hackage.haskell.org/package/angel
